### PR TITLE
Use latest cryptography

### DIFF
--- a/docker/Dockerfile.certbot
+++ b/docker/Dockerfile.certbot
@@ -37,7 +37,7 @@ RUN if [ "$(getconf LONG_BIT)" = "32" ]; then \
 	pip3 install --no-cache-dir -U cryptography==3.3.2; \
 	fi
 
-RUN pip install cryptography==2.8 \
+RUN pip install cryptography \
 	pip install --no-cache-dir cffi certbot \
 	&& pip install tldextract
 


### PR DESCRIPTION
I've built npm with (amd64 and arm64) with cryptography 38, all work as intended. Is there any reason, why we should stay on 2.8?