### PR TITLE
Include libmaxmind-dev in final image, nginx_http_geoip2 module depends on it

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,6 +61,7 @@ RUN apt-get update \
 	gettext \
 	wget \
 	xz-utils \
+	libmaxminddb-dev \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /var/cache/* /var/log/* /tmp/* /var/lib/dpkg/status-old


### PR DESCRIPTION
Adds the libmaxmind-dev package to the final image since nginx_http_geoip2 depends on it.